### PR TITLE
Fix: appid may contain special bytes.

### DIFF
--- a/SGDBoop-VS.vcxproj
+++ b/SGDBoop-VS.vcxproj
@@ -80,6 +80,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LibraryPath>$(SolutionDir)\lib\windows;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/sgdboop.c
+++ b/sgdboop.c
@@ -764,6 +764,7 @@ struct nonSteamApp* getNonSteamApps(int includeMods) {
 		fseek(fp, 0, SEEK_SET);
 
 		unsigned char* fileContent = malloc(filesize + 1);
+		unsigned char* realFileContent = malloc(filesize + 1);
 		unsigned int currentFileByte = 0;
 
 		// Load the vdf in memory and fix string-related issues
@@ -775,6 +776,7 @@ struct nonSteamApp* getNonSteamApps(int includeMods) {
 				else {
 					fileContent[currentFileByte] = buf[i];
 				}
+				realFileContent[currentFileByte] = buf[i];
 				currentFileByte++;
 			}
 		}
@@ -802,14 +804,15 @@ struct nonSteamApp* getNonSteamApps(int includeMods) {
 			unsigned char* exeEndChar = strstr(exeStartChar, "\x03");
 
 			unsigned char* appidPtr = strstr_i(parsingChar, "\002appid");
-			unsigned char* appBlockEndPtr = strstr(parsingChar, "\x08") + 1; // gcc fucks with optimization on strstr for 2 consecutive hex values. DON'T EDIT THIS.
+			unsigned char* tagsPtr = strstr(appidPtr, "\x03tags\x03");
+			unsigned char* appBlockEndPtr = strstr(tagsPtr, "\x08") + 1; // gcc fucks with optimization on strstr for 2 consecutive hex values. DON'T EDIT THIS.
 			while (*appBlockEndPtr != 0x03 && *appBlockEndPtr != 0x00) {
 				appBlockEndPtr = strstr(appBlockEndPtr, "\x08") + 1;
 			}
 
 			// If appid was found in this app block
 			if (appidPtr > 0 && appidPtr < appBlockEndPtr) {
-				unsigned char* hexBytes = appidPtr + 7;
+				unsigned char* hexBytes = realFileContent + (appidPtr - fileContent) + 7;
 				intBytes[0] = *(hexBytes + 3);
 				intBytes[1] = *(hexBytes + 2);
 				intBytes[2] = *(hexBytes + 1);


### PR DESCRIPTION
For some reasons, 0x00 bytes are set to 0x03 in `fileContent`. But, if the "appid" of non-Steam games contains some 0x00 bytes, the program will fail, since it did not get the real appid.