### PR TITLE
remove system pause on successful unregister

### DIFF
--- a/sgdboop.c
+++ b/sgdboop.c
@@ -428,7 +428,6 @@ int deleteURIprotocol() {
 
 	system("cls");
 	printf("Program unregistered successfully!\n");
-	system("pause");
 	return 0;
 #else
 	// Do nothing on linux


### PR DESCRIPTION
I'm adding this program to [scoop](https://scoop.sh) (ScoopInstaller/Extras#15791), and the unregister script makes you manually press a key even if everything was successful, which is kind of annoying.