### PR TITLE
Fix steam flatpak check permission

### DIFF
--- a/.flatpak/com.steamgriddb.SGDBoop.yml
+++ b/.flatpak/com.steamgriddb.SGDBoop.yml
@@ -8,7 +8,6 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
   - --share=network
-  - --filesystem=~/.local/state:create
   # Used for reading SteamID of user
   - --filesystem=~/.steam/steam/config/loginusers.vdf:ro
   # For saving custom images and reading shortcuts.vdf for Non-Steam games. shortcuts.vdf is also written to for non-Steam icons.
@@ -27,7 +26,6 @@ finish-args:
   - --filesystem=~/.var/app/com.valvesoftware.Steam/data/Steam/userdata:rw
   - --filesystem=~/.var/app/com.valvesoftware.Steam/data/Steam/appcache/librarycache:rw
   - --filesystem=~/.var/app/com.valvesoftware.Steam/data/registry.vdf:ro
-  - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
   # For checking Steam installation type
   - --filesystem=/var/lib/flatpak/app/com.valvesoftware.Steam:ro
 modules:

--- a/.flatpak/com.steamgriddb.SGDBoop.yml
+++ b/.flatpak/com.steamgriddb.SGDBoop.yml
@@ -28,6 +28,8 @@ finish-args:
   - --filesystem=~/.var/app/com.valvesoftware.Steam/data/Steam/appcache/librarycache:rw
   - --filesystem=~/.var/app/com.valvesoftware.Steam/data/registry.vdf:ro
   - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
+  # For checking Steam installation type
+  - --filesystem=/var/lib/flatpak/app/com.valvesoftware.Steam:ro
 modules:
   - name: sgdboop
     no-autogen: true


### PR DESCRIPTION
The Steam Flatpak check is failing when using SGDBoop Flatpak due to `/var/lib/` not being accessible by default.

https://github.com/SteamGridDB/SGDBoop/blob/575ae2218774e0b7382a09643bfd0ce8f8c69e87/sgdboop.c#L460

While at it, I cleaned 2 extra permissions that seem unused. Basic testing showed no errors.

Fixes #105