### PR TITLE
Fix game selection loop logic and shell drop issue

### DIFF
--- a/linux-release/install.sh
+++ b/linux-release/install.sh
@@ -10,8 +10,6 @@ install -Dm755 SGDBoop -t /usr/local/bin
 chmod +x /usr/local/bin/SGDBoop
 desktop-file-install com.steamgriddb.SGDBoop.desktop --delete-original --rebuild-mime-info-cache
 
-su - $SUDO_USER
-xdg-mime default com.steamgriddb.SGDBoop.desktop x-scheme-handler/sgdb
-
+su - $SUDO_USER -c "xdg-mime default com.steamgriddb.SGDBoop.desktop x-scheme-handler/sgdb"
 echo "Installation complete! You may delete this install script."
 exit 0

--- a/sgdboop.c
+++ b/sgdboop.c
@@ -1019,7 +1019,8 @@ struct nonSteamApp* selectNonSteamApp(char* sgdbName, struct nonSteamApp* apps, 
 
 
 	// Find match
-	struct nonSteamApp * matchedStruct;
+	int matchCount;
+    struct nonSteamApp * matchedStruct;
 	char ** matchedValues;
 	if (retval >= _nonSteamAppsCount) {
 		retval -= _nonSteamAppsCount;
@@ -1028,9 +1029,10 @@ struct nonSteamApp* selectNonSteamApp(char* sgdbName, struct nonSteamApp* apps, 
 	} else {
 		matchedStruct = apps;
 		matchedValues = values;
-	}
+        matchCount = _nonSteamAppsCount;
+        }
 
-	for (int i = 0; i < _nonSteamAppsCount + _modsCount; i++) {
+	for (int i = 0; i < matchCount; i++) {
 		if (strcmp(matchedStruct[i].name, matchedValues[retval]) == 0) {
 			strcpy(appData->appid, matchedStruct[i].appid);
 			strcpy(appData->name, matchedStruct[i].name);


### PR DESCRIPTION
I should have solved issue #121,

I would appreciate if someone were to test this on their end as-well before merge.

The loop in question was simply going out of bound, nothing fancy.

The fix in the install script was dropping me into an interactive shell and I am quite sure that was not supposed to be what the original author intended for it, but do feel free to not merge that change if I am wrong about that